### PR TITLE
feat: log plugin version after registering

### DIFF
--- a/src/ReactionAPICore.js
+++ b/src/ReactionAPICore.js
@@ -610,7 +610,7 @@ export default class ReactionAPICore {
       });
     }
 
-    Logger.info(`Registered plugin ${plugin.name}`);
+    Logger.info(`Registered plugin ${plugin.name} (${plugin.version || "no version"})`);
   }
 
   /**


### PR DESCRIPTION
Type: **feature**

## Changes
Plugin version is now logged with the name on startup as each plugin registers itself.

Before: `Registered plugin carts`
After: `Registered plugin carts (1.0.0)`

Will say "no version" if `version` prop isn't provided.

## Breaking changes
None

## Testing
1. Link in this branch of this package
2. Start the API
3. In startup logging, check that the logging is changed as described.