### PR TITLE
feat: add experimental collection validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This NPM package also provides the `ReactionTestAPICore` class, which you can us
 ## Installation
 
 ```sh
-npm install @reactioncommerce/api-core graphql@14.6
+npm install @reactioncommerce/api-core graphql
 ```
 
 The `graphql` package is a required peer dependency.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ collections: {
 
 The `collections` object key is where you will access this collection on `context.collections`, and `name` is the collection name in MongoDB. We recommend you make these the same if you can.
 
-The example above will make `context.collections.MyCustomCollection` available in all query and mutation functions, and all functions that receive `context`, such as startup functions. Note that usually MongoDB will not actually create the collection until the first time you insert into it.
+The example above will make `context.collections.MyCustomCollection` available in all query and mutation functions, and all functions that receive `context`, such as startup functions. Note MongoDB may not actually create the collection until the first time you insert into it.
 
 You can optionally add indexes for your MongoDB collection:
 
@@ -280,6 +280,32 @@ collections: {
 ```
 
 Each item in the `indexes` array is an array of arguments that will be passed to the Mongo `createIndex` function. The `background` option is always set to `true` so you need not include that.
+
+There is also experimental support for defining validation options. Add `validator`, `validationLevel`, or `validationAction` options and they will be passed along to the MongoDB library. Refer to [their createCollection documentation](http://mongodb.github.io/node-mongodb-native/3.6/api/Db.html#createCollection).
+
+There is also a convenience syntax that allows you to pass a JSONSchema directly. This:
+
+```js
+collections: {
+  MyCustomCollection: {
+    name: "MyCustomCollection",
+    jsonSchema: someJsonSchema
+  }
+}
+```
+
+Is shorthand for this:
+
+```js
+collections: {
+  MyCustomCollection: {
+    name: "MyCustomCollection",
+    validator: {
+      $jsonSchema: someJsonSchema
+    }
+  }
+}
+```
 
 NOTE: Registering your collections is not required, and in fact it is probably best to NOT register them unless you need to allow other plugins to access your data directly. As long as you do not register them, they remain a private implementation detail that you are free to change without breaking other plugins.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/federation": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.13.2.tgz",
-      "integrity": "sha512-62uXIIHxHXG71gSwROFt8yxtYeUZ2BaIgAkxZ1H82GB4+s1gt4xwizcmmCWqQhK3KBy4LbPOfI1YyHW4Wv5ZpQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.15.0.tgz",
+      "integrity": "sha512-L6n41obKc0fLQdZ0uSHhHRJNCIAxZ5uDeqQON+Q+ewiUfS3XetCCf/cGpiiL50TIY/n8Bvh5ZPWLMTtP0tyw5g==",
       "requires": {
         "apollo-graphql": "^0.4.0",
         "apollo-server-env": "^2.4.3",
@@ -36,18 +36,18 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+          "version": "10.17.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
+          "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
         }
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.4.tgz",
-      "integrity": "sha512-kldvB9c+vzimel4yEktlkB08gaJ5DQn9ZuIfFf1kpAw+++5hFwYRWTyKgOhF9LbOWNWGropesYC7WwLja2erhQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.8.tgz",
+      "integrity": "sha512-W2+HB8Y7ifowcf3YyPHgDI05izyRtOeZ4MqIr7LbTArtmJ0ZHULWpn84SGMW7NAvTV1tFExpHlveHhnXuJfuGA==",
       "requires": {
-        "apollo-env": "^0.6.2"
+        "apollo-env": "^0.6.5"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -1774,9 +1774,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@reactioncommerce/api-utils": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.10.0.tgz",
-      "integrity": "sha512-o4OChwtxtQqRK8p6xG0FRM94G1imWK+7ob5DgAN+XCHjSaYL7sRrIEfb9EEFS8QsFcCcBxUap4qGH93gPJ+U9Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.12.0.tgz",
+      "integrity": "sha512-5zePbau5ERFeD47xPclSmloinOPZzainxfAVghCetPVBdCxabH0EgAQ/uaHcZ4KDXrQRU80NxZ9yxTeiZrZRpQ==",
       "requires": {
         "@reactioncommerce/logger": "^1.1.3",
         "@reactioncommerce/random": "^1.0.2",
@@ -1918,6 +1918,11 @@
         "@types/node": "*"
       }
     },
+    "@types/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
+    },
     "@types/cookies": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.4.tgz",
@@ -1938,21 +1943,23 @@
       }
     },
     "@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.3.tgz",
-      "integrity": "sha512-sHEsvEzjqN+zLbqP+8OXTipc10yH1QLR+hnr5uw29gi9AhCAAAdri8ClNV7iMdrJrIzXIQtlkPvq8tJGhj3QJQ==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.6.tgz",
+      "integrity": "sha512-U2oynuRIB17GIbEdvjFrrEACOy7GQkzsX7bPEBz1H41vZYEU4j0fLL97sawmHDwHUXpUQDBMHIyM9vejqP9o1A==",
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
     },
@@ -2017,11 +2024,12 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.2.tgz",
-      "integrity": "sha512-2UPelagNNW6bnc1I5kIzluCaheXRA9S+NyOdXEFFj9Az7jc15ek5V03kb8OTbb3tdZ5i2BIJObe86PhHvpMolg==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.11.3.tgz",
+      "integrity": "sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==",
       "requires": {
         "@types/accepts": "*",
+        "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
         "@types/keygrip": "*",
@@ -2048,14 +2056,14 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "12.12.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
-      "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg=="
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
+      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
     },
     "@types/node-fetch": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
-      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -2072,6 +2080,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
+      "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -2094,9 +2107,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
+      "integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
       "requires": {
         "@types/node": "*"
       }
@@ -2158,9 +2171,9 @@
       }
     },
     "@wry/equality": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
-      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -2298,12 +2311,12 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.9.0.tgz",
-      "integrity": "sha512-iLT6IT4Ul5cMfBcJAvhpk3a7AD6fXqvFxNmJEPVapVJHbSKYIjra4PTis13sOyN5Y3WQS6a+NRFxAW8+hL3q3Q==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.10.0.tgz",
+      "integrity": "sha512-UIcPlrPdRTOKrF7kc5/WD5i6EVkGEEqgOK/fMj92fnnxR1KnQDiN82lqaxu02eZJvWjFJjik0JVJNXKOJXVrpQ==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.12.0"
       }
     },
     "apollo-datasource": {
@@ -2316,66 +2329,66 @@
       }
     },
     "apollo-engine-reporting": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.7.0.tgz",
-      "integrity": "sha512-jsjSnoHrRmk4XXK4aFU17YSJILmWsilKRwIeN74QJsSxjn5SCVF4EI/ebf/MNrTHpft8EhShx+wdkAcOD9ivqA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-1.8.0.tgz",
+      "integrity": "sha512-VPVpIGW6lbYXga6sqq/fG8ZaPR70bFuxvCov6X0npuVQPXwgZrzBp50cHx9uIaBVxDDxD3leeznsQbmF37RAww==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-engine-reporting-protobuf": "^0.5.0",
         "apollo-graphql": "^0.4.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
-        "apollo-server-types": "^0.3.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-types": "^0.4.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.12.0"
       }
     },
     "apollo-engine-reporting-protobuf": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.4.4.tgz",
-      "integrity": "sha512-SGrIkUR7Q/VjU8YG98xcvo340C4DaNUhg/TXOtGsMlfiJDzHwVau/Bv6zifAzBafp2lj0XND6Daj5kyT/eSI/w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.5.0.tgz",
+      "integrity": "sha512-OgMwtLcuL+YAaO2xgkPbnRJnISLDSNE5F11p7oq+1ws+ws71CPfHAthDCxSObCPSALdhsLAGD0v3u3soBuNmMg==",
       "requires": {
         "@apollo/protobufjs": "^1.0.3"
       }
     },
     "apollo-env": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.2.tgz",
-      "integrity": "sha512-Vb/doL1ZbzkNDJCQ6kYGOrphRx63rMERYo3MT2pzm2pNEdm6AK60InMgJaeh3RLK3cjGllOXFAgP8IY+m+TaEg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.5.tgz",
+      "integrity": "sha512-jeBUVsGymeTHYWp3me0R2CZRZrFeuSZeICZHCeRflHTfnQtlmbSXdy5E0pOyRM9CU4JfQkKDC98S1YglQj7Bzg==",
       "requires": {
-        "@types/node-fetch": "2.5.5",
+        "@types/node-fetch": "2.5.7",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.1.tgz",
-      "integrity": "sha512-dz2wtGeCqUDAKAj4KXLKLZiFY791aoXduul3KcLo8/6SwqWlsuZiPe0oB8mENHZZc/EchCpTMTJZX2ZENsOt2A==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.4.4.tgz",
+      "integrity": "sha512-i012iRKT5nfsOaNMx4MTwHw2jrlyaF1zikpejxsGHsKIf3OngGvGh3pyw20bEmwj413OrNQpRxvvIz5A7W/8xw==",
       "requires": {
-        "apollo-env": "^0.6.2",
+        "apollo-env": "^0.6.5",
         "lodash.sortby": "^4.7.0"
       }
     },
     "apollo-link": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
-      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
       "requires": {
         "apollo-utilities": "^1.3.0",
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.20"
+        "zen-observable-ts": "^0.8.21"
       }
     },
     "apollo-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.11.0.tgz",
-      "integrity": "sha512-UhW6RHPBMWZy1v7KhzssUnxPBxpu9fGFajtqP68vtvvP3+xa2Y2GUg0594bHcUcLK+BjdMBQQSW27i0yQ/Fz9g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.13.0.tgz",
+      "integrity": "sha512-hbfxbgi6bpteBki2aKHRxS5FvsqpL7TLOrR99jWibCxVY2RYZZ0DtiT7RyFDZ0SLohdKzut2Rri67waRXBcDnA==",
       "requires": {
-        "apollo-server-core": "^2.11.0",
-        "apollo-server-express": "^2.11.0",
+        "apollo-server-core": "^2.13.0",
+        "apollo-server-express": "^2.13.0",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
@@ -2390,28 +2403,29 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.11.0.tgz",
-      "integrity": "sha512-jHLOqwTRlyWzqWNRlwr2M/xfrt+lw2pHtKYyxUGRjWFo8EM5TX1gDcTKtbtvx9p5m+ZBDAhcWp/rpq0vSz4tqg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.13.0.tgz",
+      "integrity": "sha512-PqfsexbyObaQYb2jODs8v/XzrJcn+5mh0jA8ZfQCg5GENlua/CjeTZbRm2X0p3qpwc2E5jFAXSshrIWvhQAGZQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/graphql-upload": "^8.0.0",
-        "@types/ws": "^6.0.0",
-        "apollo-cache-control": "^0.9.0",
+        "@types/ws": "^7.0.0",
+        "apollo-cache-control": "^0.10.0",
         "apollo-datasource": "^0.7.0",
-        "apollo-engine-reporting": "^1.7.0",
+        "apollo-engine-reporting": "^1.8.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.4.0",
-        "apollo-server-plugin-base": "^0.7.0",
-        "apollo-server-types": "^0.3.0",
-        "apollo-tracing": "^0.9.0",
+        "apollo-server-errors": "^2.4.1",
+        "apollo-server-plugin-base": "^0.8.0",
+        "apollo-server-types": "^0.4.0",
+        "apollo-tracing": "^0.10.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.11.0",
+        "graphql-extensions": "^0.12.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
         "graphql-upload": "^8.0.2",
+        "loglevel": "^1.6.7",
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "ws": "^6.0.0"
@@ -2427,23 +2441,23 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.0.tgz",
-      "integrity": "sha512-ZouZfr2sGavvI18rgdRcyY2ausRAlVtWNOax9zca8ZG2io86dM59jXBmUVSNlVZSmBsIh45YxYC0eRvr2vmRdg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.1.tgz",
+      "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
     },
     "apollo-server-express": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.11.0.tgz",
-      "integrity": "sha512-9bbiD+zFAx+xyurc9lxYmNa9y79k/gsA1vEyPFVcv7jxzCFC5wc0tcbV7NPX2qi1Nn7K76fxo2fPNYbPFX/y0g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.13.0.tgz",
+      "integrity": "sha512-xDc+kRqWCXs4MeRjls37G45V6PmKYwo7OlpWCXyWDSPGgY9UD4E5A6rUBCyIhoNr7RnVYMkNuySOOqzX1QJ7EA==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
         "@types/cors": "^2.8.4",
-        "@types/express": "4.17.2",
+        "@types/express": "4.17.4",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.11.0",
-        "apollo-server-types": "^0.3.0",
+        "apollo-server-core": "^2.13.0",
+        "apollo-server-types": "^0.4.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "express": "^4.17.1",
@@ -2455,50 +2469,51 @@
       },
       "dependencies": {
         "@types/express": {
-          "version": "4.17.2",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-          "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.4.tgz",
+          "integrity": "sha512-DO1L53rGqIDUEvOjJKmbMEQ5Z+BM2cIEPy/eV3En+s166Gz+FeuzRerxcab757u/U4v4XF4RYrZPmqKa+aY/2w==",
           "requires": {
             "@types/body-parser": "*",
             "@types/express-serve-static-core": "*",
+            "@types/qs": "*",
             "@types/serve-static": "*"
           }
         }
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.7.0.tgz",
-      "integrity": "sha512-//xgYrBYLQSr92W0z3mYsFGoVz3wxKNsv3KcOUBhbOCGTbjZgP7vHOE1vhHhRcpZKKXmjXTVONdrnNJ+XVGi6A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.8.0.tgz",
+      "integrity": "sha512-H8sJlOVJrF0IhYIFMv7NOgB6BFgqobXSZrj1y9ju6dq13OotsqcZC4fJOYc9oWzb/+/mqg/odtVioE71mj68yg==",
       "requires": {
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.4.0"
       }
     },
     "apollo-server-testing": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-testing/-/apollo-server-testing-2.11.0.tgz",
-      "integrity": "sha512-iqb20FYmkM6VJ9s4M78J8lXabZSDZCt8V2/As1x2zvgZ8bOdX77fR5UxrkkV/zR6bwd7252wIiHp/m9FF9O2zA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-testing/-/apollo-server-testing-2.13.0.tgz",
+      "integrity": "sha512-plnh1e+AabrGIW1RH/rjFFQXlzRCqYENoc4/V28NadtT/yRBwAG/O/Ci9dCFnmV/9VfvIdsRLGPwZpyKt4KjVA==",
       "requires": {
-        "apollo-server-core": "^2.11.0"
+        "apollo-server-core": "^2.13.0"
       }
     },
     "apollo-server-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.3.0.tgz",
-      "integrity": "sha512-FMo7kbTkhph9dfIQ3xDbRLObqmdQH9mwSjxhGsX+JxGMRPPXgd3+GZvCeVKOi/udxh//w1otSeAqItjvbj0tfQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.4.0.tgz",
+      "integrity": "sha512-U+6qKCdrucVSMEVvLSqSwxIGr3VI6vcfbhpD86sdb8MgHHGH6egjNAcLrPVRk1AyXs8RV0Ysus+vlj8rpouBzA==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "^0.4.4",
+        "apollo-engine-reporting-protobuf": "^0.5.0",
         "apollo-server-caching": "^0.5.1",
         "apollo-server-env": "^2.4.3"
       }
     },
     "apollo-tracing": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.9.0.tgz",
-      "integrity": "sha512-oqspTrf4BLGbKkIk1vF+I31C2v7PPJmF36TFpT/+zJxNvJw54ji4ZMhtytgVqbVldQEintJmdHQIidYBGKmu+g==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.10.0.tgz",
+      "integrity": "sha512-yuqA1KT0FQUfzVK3ZIk0hRIE8eUKx9Oklq83AGQxLtS/oafBj/VOCZAtJNJkyEqMJxXQT9uIBtbfO1789Gczkw==",
       "requires": {
         "apollo-server-env": "^2.4.3",
-        "graphql-extensions": "^0.11.0"
+        "graphql-extensions": "^0.12.0"
       }
     },
     "apollo-utilities": {
@@ -3568,9 +3583,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.4",
@@ -5059,13 +5074,13 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.11.0.tgz",
-      "integrity": "sha512-zd4qfUiJoYBx2MwJusM36SEJ+YmJ1ki8YF8nlm9mgaPDUzsnmFq4lxULxUfhLAXFwZw7MbEN2vV4V6WiNgSJLg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.12.0.tgz",
+      "integrity": "sha512-kBRLtNeknrFl0W/UQQYebj6qnvb1E1RpQ2+C7Y8pwMc6yV8+9pWFx5RP0HzfeEuScCmK93i3H5sdPedoQWwENw==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-types": "^0.3.0"
+        "apollo-server-types": "^0.4.0"
       }
     },
     "graphql-fields": {
@@ -5186,11 +5201,11 @@
       "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
     },
     "graphql-tools": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.7.tgz",
-      "integrity": "sha512-rApl8sT8t/W1uQRcwzxMYyUBiCl/XicluApiDkNze5TX/GR0BSTQMjM2UcRGdTmkbsb1Eqq6afkyyeG/zMxZYQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.8.tgz",
+      "integrity": "sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==",
       "requires": {
-        "apollo-link": "^1.2.3",
+        "apollo-link": "^1.2.14",
         "apollo-utilities": "^1.0.1",
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
@@ -6639,180 +6654,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash._basecallback": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
-      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
-      "requires": {
-        "lodash._baseisequal": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.pairs": "^3.0.0"
-      }
-    },
-    "lodash._baseeach": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
-      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
-      "requires": {
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basefind": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
-      "integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4="
-    },
-    "lodash._basefindindex": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
-      "integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8="
-    },
-    "lodash._baseisequal": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
-      "requires": {
-        "lodash.isarray": "^3.0.0",
-        "lodash.istypedarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._baseismatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
-      "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
-      "requires": {
-        "lodash._baseisequal": "^3.0.0"
-      }
-    },
-    "lodash._basematches": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
-      "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
-      "requires": {
-        "lodash._baseismatch": "^3.0.0",
-        "lodash.pairs": "^3.0.0"
-      }
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash.every": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
-      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
-    },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
-    "lodash.findwhere": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.findwhere/-/lodash.findwhere-3.1.0.tgz",
-      "integrity": "sha1-eTfTTz6sgY3sf6lOjKXib9uhz8E=",
-      "requires": {
-        "lodash._basematches": "^3.0.0",
-        "lodash.find": "^3.0.0"
-      },
-      "dependencies": {
-        "lodash.find": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
-          "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
-          "requires": {
-            "lodash._basecallback": "^3.0.0",
-            "lodash._baseeach": "^3.0.0",
-            "lodash._basefind": "^3.0.0",
-            "lodash._basefindindex": "^3.0.0",
-            "lodash.isarray": "^3.0.0",
-            "lodash.keys": "^3.0.0"
-          }
-        }
-      }
-    },
-    "lodash.foreach": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
-    },
-    "lodash.istypedarray": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
-    "lodash.pairs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
-      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
-      "requires": {
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.set": {
       "version": "4.3.2",
@@ -6829,7 +6680,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -6839,7 +6689,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -6850,25 +6699,15 @@
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
-    "lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "lodash.without": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
-    },
     "lodash.xorby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.xorby/-/lodash.xorby-4.7.0.tgz",
       "integrity": "sha1-nBmm+fBjputT3QPBtocXmYAUY9c="
+    },
+    "loglevel": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
     },
     "lolex": {
       "version": "5.1.2",
@@ -7127,11 +6966,11 @@
       "dev": true
     },
     "message-box": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.2.tgz",
-      "integrity": "sha512-A32m9D2ZaE08ZaXoE74AjcKwjtwwEhDT2EeY7A3YMAEB4ypL0uMZw7HegwZ806GIWyY4VLwe3kGO9reIdjwiRg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.5.tgz",
+      "integrity": "sha512-e/WxhROs2CZ8iSp2lsv0kSVuJxvxTVpcqXxvKgvyniQpbL/jcHBIf/0mqT7Y65c1Okr4ZUDP6PdK8h3k5Ot22w==",
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash.template": "^4.5.0"
       }
     },
     "methods": {
@@ -7231,23 +7070,17 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongo-object": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.3.tgz",
-      "integrity": "sha512-m3vs+a1JkvRXELJMe2ieMmBe03NUy6bctGjWicRhReYj8brDi0ojKHLKLmXWr/RupNaFP8Q7/x8xG8GpFtp9wg==",
-      "requires": {
-        "lodash.foreach": "^4.5.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isobject": "^3.0.2",
-        "lodash.without": "^4.4.0"
-      }
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.4.tgz",
+      "integrity": "sha512-QtYk0gupWEn2+iB+DDRt1L+WbcNYvJRaHdih/dcqthOa1DbnREUGSs2WGcW478GNYpElflo/yybZXu0sTiRXHg=="
     },
     "mongodb": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.5.tgz",
-      "integrity": "sha512-GCjDxR3UOltDq00Zcpzql6dQo1sVry60OXJY3TDmFc2SWFY6c8Gn1Ardidc5jDirvJrx2GC3knGOImKphbSL3A==",
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.7.tgz",
+      "integrity": "sha512-lMtleRT+vIgY/JhhTn1nyGwnSMmJkJELp+4ZbrjctrnBxuLbj6rmLuJFz8W2xUzUqWmqoyVxJLYuC58ZKpcTYQ==",
       "requires": {
         "bl": "^2.2.0",
-        "bson": "^1.1.1",
+        "bson": "^1.1.4",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
@@ -8749,24 +8582,13 @@
       "dev": true
     },
     "simpl-schema": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.7.tgz",
-      "integrity": "sha512-YxezVU4odQK6kY6NcmdypkS0MntahpfVpbK0zZCyI+12V43imynM/z024W+iHJpaL2aFDqZYgOVbeg8HjZU3ZQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.7.0.tgz",
+      "integrity": "sha512-QjZXjoGeyzHmKZ8j7uomOivwLXwpENWtRvOwwj+2gilAtvs+jfD5IhIT0NF08oY4gHVgngVJB3rRWBku5JhmcA==",
       "requires": {
         "clone": "^2.1.2",
-        "extend": "^3.0.2",
-        "lodash.every": "^4.6.0",
-        "lodash.find": "^4.6.0",
-        "lodash.findwhere": "^3.1.0",
-        "lodash.includes": "^4.3.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isobject": "^3.0.2",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "lodash.union": "^4.6.0",
-        "lodash.uniq": "^4.5.0",
-        "message-box": "^0.2.2",
-        "mongo-object": "^0.1.3"
+        "message-box": "^0.2.5",
+        "mongo-object": "^0.1.4"
       }
     },
     "sisteransi": {
@@ -9483,11 +9305,11 @@
       }
     },
     "transliteration": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.1.8.tgz",
-      "integrity": "sha512-ds3uRxcS0yCxzP4xP30dz+ImEeVhgAwSaewhlApuYYTUuT8+wFFLoFfO1nHvfJzbpoRBp4lS52Ai3wm8IkemIQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.1.9.tgz",
+      "integrity": "sha512-Vi/WAvipvnA75VWcxPTxgXdm4bUrGTlg4okMVBBw/KZVHnR3CGZXvpYAsMFdpkyRl2mwGpwK0DM/LznZ7R2lDg==",
       "requires": {
-        "yargs": "^15.0.2"
+        "yargs": "^15.3.1"
       }
     },
     "trim-newlines": {
@@ -9972,9 +9794,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
-      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
       "requires": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     ]
   },
   "dependencies": {
-    "@apollo/federation": "^0.13.2",
-    "@reactioncommerce/api-utils": "^1.10.0",
+    "@apollo/federation": "^0.15.0",
+    "@reactioncommerce/api-utils": "^1.12.0",
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/random": "^1.0.2",
     "@reactioncommerce/reaction-error": "^1.0.1",
-    "apollo-server": "^2.11.0",
-    "apollo-server-express": "^2.11.0",
-    "apollo-server-testing": "^2.11.0",
+    "apollo-server": "^2.13.0",
+    "apollo-server-express": "^2.13.0",
+    "apollo-server-testing": "^2.13.0",
     "body-parser": "^1.19.0",
     "callsite": "^1.0.0",
     "cors": "^2.8.5",
@@ -66,14 +66,14 @@
     "express": "^4.17.1",
     "graphql-iso-date": "^3.6.1",
     "lodash": "^4.17.15",
-    "mongodb": "^3.5.5",
+    "mongodb": "^3.5.7",
     "promise-retry": "^1.1.1",
-    "simpl-schema": "^1.5.7"
+    "simpl-schema": "^1.7.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",
     "@babel/preset-env": "~7.9.0",
-    "@commitlint/cli": "^8.3.5",
+    "@commitlint/cli": "~8.3.5",
     "@commitlint/config-conventional": "~8.3.4",
     "@reactioncommerce/babel-remove-es-create-require": "~1.0.0",
     "@reactioncommerce/data-factory": "~1.0.1",
@@ -87,7 +87,7 @@
     "eslint-plugin-import": "~2.18.2",
     "eslint-plugin-jest": "~22.17.0",
     "eslint-plugin-jsx-a11y": "~6.2.3",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-react": "~7.14.3",
     "eslint-plugin-react-hooks": "~2.0.1",
@@ -97,7 +97,7 @@
     "jest": "~25.2.7"
   },
   "peerDependencies": {
-    "graphql": "~14.6.0"
+    "graphql": "^14.6.0 || ^15.0.0"
   },
   "commitlint": {
     "extends": [

--- a/src/ReactionAPICore.js
+++ b/src/ReactionAPICore.js
@@ -258,8 +258,36 @@ export default class ReactionAPICore {
                 collectionOptions.validationAction = collectionConfig.validationAction;
               }
 
-              // Add the collection instance to `context.collections`
-              this.collections[collectionKey] = await this.db.createCollection(collectionConfig.name, collectionOptions); // eslint-disable-line no-await-in-loop
+              /* eslint-disable promise/no-promise-in-callback */
+
+              // Add the collection instance to `context.collections`.
+              // If the collection already exists, we need to modify it instead of calling
+              // `createCollection`, in order to add validation options.
+              const getCollectionPromise = new Promise((resolve, reject) => {
+                this.db.collection(collectionConfig.name, { strict: true }, (error, collection) => {
+                  if (error) {
+                    // Collection with this name doesn't yet exist
+                    this.db.createCollection(collectionConfig.name, collectionOptions)
+                      .then((newCollection) => {
+                        resolve(newCollection);
+                        return null;
+                      })
+                      .catch(reject);
+                  } else {
+                    // Collection with this name exists, so modify before resolving
+                    this.db.command({ collMod: collectionConfig.name, ...collectionOptions })
+                      .then(() => {
+                        resolve(collection);
+                        return null;
+                      })
+                      .catch(reject);
+                  }
+                });
+              });
+
+              /* eslint-enable promise/no-promise-in-callback */
+
+              this.collections[collectionKey] = await getCollectionPromise; // eslint-disable-line no-await-in-loop
 
               // If the collection config has `indexes` key, define all requested indexes
               if (Array.isArray(collectionConfig.indexes)) {

--- a/src/ReactionAPICore.js
+++ b/src/ReactionAPICore.js
@@ -241,8 +241,25 @@ export default class ReactionAPICore {
                   " but another plugin has already defined a collection with that key");
               }
 
+              // Pass through certain supported collection options
+              const collectionOptions = {};
+              if (collectionConfig.jsonSchema) {
+                collectionOptions.validator = {
+                  $jsonSchema: collectionConfig.jsonSchema
+                };
+              } else if (collectionConfig.validator) {
+                collectionOptions.validator = collectionConfig.validator;
+              }
+
+              if (collectionConfig.validationLevel) {
+                collectionOptions.validationLevel = collectionConfig.validationLevel;
+              }
+              if (collectionConfig.validationAction) {
+                collectionOptions.validationAction = collectionConfig.validationAction;
+              }
+
               // Add the collection instance to `context.collections`
-              this.collections[collectionKey] = this.db.collection(collectionConfig.name);
+              this.collections[collectionKey] = await this.db.createCollection(collectionConfig.name, collectionOptions); // eslint-disable-line no-await-in-loop
 
               // If the collection config has `indexes` key, define all requested indexes
               if (Array.isArray(collectionConfig.indexes)) {


### PR DESCRIPTION
Type: **feature**

## Changes
ReactionAPICore now passes through some validation-related collection options when defining collections. The upshot is that plugins may now choose to experiment with passing a JSON schema to MongoDB and allowing it to do all data validation for create and update operations.

Refer to the README updates for more details.

This was originally implemented by @set321go in https://github.com/reactioncommerce/reaction/pull/6163

## Breaking changes
None

## Testing
Register a test plugin that uses the `jsonSchema` option and verify that you cannot insert invalid data.