### PR TITLE
Fix circleci integration tests unified topology

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:12.14.1
+      - image: node:14.15.0
 
     dependencies:
       pre:
@@ -20,7 +20,7 @@ jobs:
 
   deploy:
     docker:
-      - image: node:12.14.1
+      - image: node:14.15.0
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
 
   lint-code:
     docker:
-      - image: node:12.14.1
+      - image: node:14.15.0
 
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
 
   lint-graphql:
     docker:
-      - image: node:12.14.1
+      - image: node:14.15.0
 
     steps:
       - checkout
@@ -65,7 +65,7 @@ jobs:
 
   test:
     docker:
-      - image: node:12.14.1
+      - image: node:14.15.0
 
     steps:
       - checkout

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,1 +1,1 @@
-module.exports = require("@reactioncommerce/api-utils/lib/configs/babel.config.cjs");
+module.exports = require("@reactioncommerce/api-utils/configs/babel.config.cjs");

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,1 +1,1 @@
-module.exports = require("@reactioncommerce/api-utils/lib/configs/jest.config.cjs");
+module.exports = require("@reactioncommerce/api-utils/configs/jest.config.cjs");

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,10 @@ export default envalid.cleanEnv(process.env, {
     desc: "A valid MongoDB connection string URI, ending with the database name",
     example: "mongodb://localhost:27017/reaction"
   }),
+  MONGO_USE_UNIFIED_TOPOLOGY: bool({
+    default: true,
+    desc: "MongoDB's useUnifiedTopology connection option"
+  }),
   PORT: num({
     default: 3000,
     desc: "The port on which the API server should listen",

--- a/src/util/mongoConnectWithRetry.js
+++ b/src/util/mongoConnectWithRetry.js
@@ -1,6 +1,7 @@
 import Logger from "@reactioncommerce/logger";
 import mongodb from "mongodb";
 import promiseRetry from "promise-retry";
+import config from "../config.js";
 
 const { MongoClient } = mongodb;
 
@@ -24,7 +25,7 @@ export default function mongoConnectWithRetry(url) {
 
     return MongoClient.connect(url, {
       useNewUrlParser: true,
-      useUnifiedTopology: true
+      useUnifiedTopology: config.MONGO_USE_UNIFIED_TOPOLOGY
     }).then((client) => {
       Logger.info(`Connected to MongoDB. Database name: ${client.db().databaseName}`);
       return client;


### PR DESCRIPTION
Type: **bugfix**

## Issue
CircleCI tests were failing with timeouts connecting to mongodb. This mongodb configuration option needs to be `useUnifiedTopology: false` in circleci for the connections to work.

## Solution

Allow this to be controlled via configuration, which can use environment variables, which we will use in reaction core to make CI pass again.

Maintain the existing config which is `true` as the default.

## Breaking changes

The existing config is the default so behavior should be non-breaking.

## Testing
1. Try linking this PR branch into your reaction api and make sure it runs and graphql queries hit mongodb OK
