### PR TITLE
fix: lock mongodb package to v3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "express": "^4.17.1",
     "graphql-iso-date": "^3.6.1",
     "lodash": "^4.17.15",
-    "mongodb": "^3.5.7",
+    "mongodb": "3.6.2",
     "promise-retry": "^1.1.1",
     "simpl-schema": "^1.7.0"
   },


### PR DESCRIPTION
Type: **bugfix**

## Issue
Mongo is not always starting as expected when running reaction. It stalls when trying to find a replica set, and doesn't always start. I've narrowed it down to an issue with mongo `v3.6.3`, and tested versions up to `v3.6.3`, with `v3.6.2` performing as expected.

There are related issues in the Mongo Jira that I've left comments on to track so we know when there is a solution:
https://jira.mongodb.org/browse/NODE-2966
https://jira.mongodb.org/browse/NODE-2878

## Solution
Lock the mongodb install to version `3.6.2` until their issue is fixed.

## Breaking changes
None

## Testing
1. Start reaction
2. See it starts and doesn't error out when a replica mongo set can't be created / found