### PR TITLE
fix: Turn off Apollo `uploads`

### DIFF
--- a/src/createApolloServer.js
+++ b/src/createApolloServer.js
@@ -118,7 +118,8 @@ export default function createApolloServer(options = {}) {
     schema,
     subscriptions,
     introspection: config.GRAPHQL_INTROSPECTION_ENABLED,
-    playground: config.GRAPHQL_PLAYGROUND_ENABLED
+    playground: config.GRAPHQL_PLAYGROUND_ENABLED,
+    uploads: false
   });
 
   const gqlMiddleware = expressMiddleware.filter((def) => def.route === "graphql" || def.route === "all");


### PR DESCRIPTION
Resolves #issueNumber
Type: **bugfix**

## Issue
I want to add file uploads to my graphql schema but I can't because of incompatibility of Node, Apollo, graphql-upload versions.

graphql-upload used by Apollo v2 doesn't work with Node v14 so better option would be to disable it completely so reaction users can connect fresh `graphql-upload` by themselves.

https://www.apollographql.com/docs/apollo-server/v2/data/file-uploads/#uploads-in-node-14-and-later

FYI: I tried to simply downgrade to node v12 but reaction api core is not compatible with node v12 because of `??` operator.

## Solution
Possible solutions:
1. upgrade apollo
2. add `uploads: false` to Apollo constructor

Decided to simply add `uploads: false` since it's less risky than upgrading Apollo

## Breaking changes
This change could possibly had breaking changes if anyone was using integrated into Apollo v2 `graphql-upload` but since this package is not compatible with Node v12 I doubt it affects anybody

## Testing
1. A simple plugin can be added with fresh graphql-upload package:

```
import {GraphQLUpload, graphqlUploadExpress} from 'graphql-upload';
import {nanoid} from 'nanoid';
import {unlink} from 'node:fs/promises';
import {createWriteStream} from 'node:fs';

export default async function register(app) {
    await app.registerPlugin({
        label: 'Graphql-upload',
        name: 'graphql-upload',
        version: '1.0.0',
        expressMiddleware: [
            {
                route: 'graphql',
                stage: 'first',
                fn: graphqlUploadExpress,
            },
        // ],
        graphQL: {
            resolvers: {
                Upload: GraphQLUpload,
            },
            schemas: [
                `
                scalar Upload
                `,
            ],
        },
        mutations: {
            async uploadFile(context, {file}) {
                const {createReadStream, filename} = await file;
                const stream = createReadStream();
                const storedFileName = `${nanoid()}-${filename}`;
                const storedFileUrl = new URL(
                    storedFileName,
                    UPLOAD_DIRECTORY_URL,
                );

                await new Promise((resolve, reject) => {
                    const writeStream = createWriteStream(storedFileUrl);

                    writeStream.on('finish', resolve);

                    writeStream.on('error', async (error) => {
                        try {
                            await unlink(storedFileUrl);
                        } finally {
                            reject(error);
                        }
                    });

                    stream.on('error', (error) => writeStream.destroy(error));

                    stream.pipe(writeStream);
                });

                return storedFileName;
            },
        },
    });
```
