### PR TITLE
feat: adds a health check endpoint

### DIFF
--- a/src/createApolloServer.js
+++ b/src/createApolloServer.js
@@ -161,6 +161,12 @@ export default function createApolloServer(options = {}) {
     app.handle(req, res);
   });
 
+  // Add a health check API
+  app.all("/health", (req, res) => {
+    res.status(200);
+    res.send("Server running");
+  });
+
   apolloServer.applyMiddleware({ app, cors: true, path });
 
   return {


### PR DESCRIPTION
Signed-off-by: Akarshit Wal <akarshitwal@gmail.com>

This PR adds a health check endpoint to the API server. To me it seems that this would be the best place for this to exist. Adding a whole plugin, just to have a endpoint, which should definitely be present doesn't make sense.

